### PR TITLE
Avoid potential division by zero in landmark density analysis

### DIFF
--- a/analyses/modules/analysis_landmarks.py
+++ b/analyses/modules/analysis_landmarks.py
@@ -196,7 +196,9 @@ class LandmarkAnalysis(Analysis):
         """
         shares_with_labels = []
         for key in self.density.keys():
-            percentage = round(100 * self.density[key] / self.density_sum, 2)
+            percentage = 0.0
+            if self.density_sum > 0:
+                percentage = round(100 * self.density[key] / self.density_sum, 2)
             shares_with_labels.append((percentage, f"{self.plot_labels[key]} ({percentage}%)"))
 
         for pair in shares_with_labels.copy():


### PR DESCRIPTION
While the method `create_plot` is already only called in case such an error cannot occur, it makes sense to adjust the method itself so that future changes do not produce this error