### PR TITLE
fix misaligned arrows in index2.html, especially when scaling the page

### DIFF
--- a/sketch_map_tool/static/style/base.css
+++ b/sketch_map_tool/static/style/base.css
@@ -107,6 +107,7 @@ nav {
     padding: 0.5rem 1.5rem;
     min-height: 7rem;
     min-width: 5rem;
+    max-width: 15rem;
 }
 
 .horizontal.step-arrows > div.active {
@@ -128,16 +129,4 @@ nav {
 
 .vertical.step-arrows > div.active {
     background-image: url("/static/assets/active_step_arrow_vertical.svg");
-}
-
-@media screen and (max-width: 999px) {
-    .horizontal.step-arrows {
-        display: none;
-    }
-}
-
-@media screen and (min-width: 1000px) {
-    .vertical.step-arrows {
-        display: none;
-    }
 }

--- a/sketch_map_tool/static/style/index.css
+++ b/sketch_map_tool/static/style/index.css
@@ -1,3 +1,15 @@
+@media screen and (max-width: 999px) {
+    .horizontal.step-arrows {
+        display: none;
+    }
+}
+
+@media screen and (min-width: 1000px) {
+    .vertical.step-arrows {
+        display: none;
+    }
+}
+
 #main-grid {
     background: linear-gradient(#000, #000) center/2px 100% no-repeat;
     grid-template-columns: 1fr 4rem 1fr;
@@ -5,6 +17,16 @@
     align-items: center;
     grid-row-gap: 3.5rem;
     padding: 0 3rem;
+}
+
+#span-grid-row-for-arrows {
+    grid-column: 1 / 4;
+    justify-self: stretch;
+}
+
+#row-grid {
+    grid-template-columns: 1fr 4rem 1fr;
+    justify-items: center;
 }
 
 #then {

--- a/sketch_map_tool/templates/index2.html
+++ b/sketch_map_tool/templates/index2.html
@@ -27,14 +27,20 @@
             {#row 3#}
 
             {#for larger screens use horizontal arrows#}
-            <div class="horizontal step-arrows" style="grid-column: 1 / 4">
-                <div class="active">Define your Area of Interest</div>
-                <div class="">OSM Quality Check</div>
-                <div class="">PDF Export of SketchMap</div>
-                <div style="background: none; flex:0.25;"></div>
-                <div class="active">Scan or photograph your scribbled SketchMaps</div>
-                <div class="">Upload your SketchMaps</div>
-                <div class="">Download sketches as Geodata</div>
+            <div id="span-grid-row-for-arrows">
+                <div id="row-grid" class="grid">
+                    <div id="left-arrows" class="horizontal step-arrows">
+                        <div class="active">Define your Area of Interest</div>
+                        <div class="">OSM Quality Check</div>
+                        <div class="">PDF Export of SketchMap</div>
+                    </div>
+                    <div id="middle_blank"></div>
+                    <div id="right-arrows" class="horizontal step-arrows">
+                        <div class="active">Scan or photograph your scribbled SketchMaps</div>
+                        <div class="">Upload your SketchMaps</div>
+                        <div class="">Download sketches as Geodata</div>
+                    </div>
+                </div>
             </div>
 
             {#for small screens use horizontal arrows#}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2814068/197796842-f407600a-dcb2-4b8b-bb5a-3e7d8512a0dd.png)

Arrows now keep being centered in their columns