### PR TITLE
add explicit download names, esp. file-endings

### DIFF
--- a/sketch_map_tool/routes.py
+++ b/sketch_map_tool/routes.py
@@ -174,21 +174,25 @@ def download(uuid: str, type_: REQUEST_TYPES) -> Response:
     match type_:
         case "quality-report":
             mimetype = "application/pdf"
+            download_name = type_ + ".pdf"
             if task.successful():
                 file: BytesIO = task.get()
         case "sketch-map":
             mimetype = "application/pdf"
+            download_name = type_ + ".pdf"
             if task.successful():
                 file: BytesIO = task.get()[0]  # return only the sketch map
         case "raster-results":
             mimetype = "application/zip"
+            download_name = type_ + ".zip"
             if task.successful():
                 file = task.get()
         case "vector-results":
             mimetype = "application/geo+json"
+            download_name = type_ + ".geojson"
             if task.successful():
                 file = BytesIO(geojson.dumps(task.get()).encode("utf-8"))
-    return send_file(file, mimetype)
+    return send_file(file, mimetype, download_name=download_name)
 
 
 @app.errorhandler(QRCodeError)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def format_():
         compass_scale=0.25,
         globe_scale=0.125,
         scale_height=0.33,
-        qr_y=0.1,
+        qr_y=1.0,
         indent=0.25,
         qr_contents_distances_not_rotated=(2, 3),
         qr_contents_distance_rotated=3,


### PR DESCRIPTION
mimetype information is not enough in all cases. My smartfone downloaded geojson as *.bin.
So explicitly add download_names seems to be a good idea.
