### PR TITLE
feat(celery/db): enable beat to run backup cleanup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
       SMT-DATA-STORE: "redis://redis:6379"
       SMT-BROKER-URL: "redis://redis:6379"
       SMT-RESULT-BACKEND: "db+postgresql://smt:smt@postgres:5432"
-    entrypoint: ["poetry", "run", "celery", "--app", "sketch_map_tool.tasks", "worker", "--concurrency", "4", "--loglevel", "WARNING", "-E"]
+    entrypoint: ["poetry", "run", "celery", "--app", "sketch_map_tool.tasks", "worker", "--beat", "--concurrency", "4", "--loglevel", "WARNING", "-E"]
   redis:
     image: redis:7
     restart: unless-stopped

--- a/sketch_map_tool/__init__.py
+++ b/sketch_map_tool/__init__.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from celery import Celery
 from flask import Flask
 
@@ -18,6 +20,9 @@ def make_flask() -> Flask:
             "result_compression": "gzip",
             "result_chord_join_timeout": 10.0,  # default: 3.0 seconds
             "result_chord_retry_interval": 3.0,  # default: 1.0 seconds
+            # A built-in periodic task will delete the results after this time,
+            # assuming that celery beat is enabled.
+            "result_expires": timedelta(days=1),
             "accept_content": ["application/json", "application/x-python-serialize"],
             # Reserve at most one extra task for every worker process.
             "worker_prefetch_multiplier": 1,


### PR DESCRIPTION
A built-in periodic task will delete the results