### PR TITLE
Fix #203: Close matplotlib scale figure after saving

### DIFF
--- a/sketch_map_tool/map_generation/generate_pdf.py
+++ b/sketch_map_tool/map_generation/generate_pdf.py
@@ -281,6 +281,7 @@ def add_scalebar(input_image: BytesIO, m_per_px: float) -> BytesIO:
     # write output
     figure_output = BytesIO()
     plt.savefig(figure_output, dpi="figure", format="png")
+    plt.close()
     figure_output.seek(0)
 
     # convert from RGB to RGBA


### PR DESCRIPTION
Closes #203 