### PR TITLE
fix: apply breaking Changes in OQT

### DIFF
--- a/sketch_map_tool/oqt_analyses/generate_pdf.py
+++ b/sketch_map_tool/oqt_analyses/generate_pdf.py
@@ -53,7 +53,7 @@ def generate_pdf(report_properties: dict) -> BytesIO:
         result = indicator["result"]
 
         indicator_heading = Paragraph(
-            "{} ({})".format(indicator["metadata"]["name"], indicator["layer"]["name"]),
+            "{} ({})".format(indicator["metadata"]["name"], indicator["topic"]["name"]),
             styles["Heading3"],
         )
         indicator_heading.keepWithNext = True

--- a/sketch_map_tool/oqt_analyses/oqt_client.py
+++ b/sketch_map_tool/oqt_analyses/oqt_client.py
@@ -4,7 +4,7 @@ from sketch_map_tool.exceptions import OQTReportError
 from sketch_map_tool.models import Bbox
 
 OQT_API_URL = "https://oqt.ohsome.org/api"
-OQT_REPORT_NAME = "SketchmapFitness"
+OQT_REPORT_NAME = "sketchmap-fitness"
 
 
 def bbox_to_polygon(bbox: Bbox) -> dict:
@@ -31,8 +31,8 @@ def get_report(bbox: Bbox, include_svg: bool = True, include_html: bool = False)
     parameters = {
         "name": OQT_REPORT_NAME,
         "bpolys": bbox_to_polygon(bbox),
-        "includeSvg": include_svg,
-        "includeHtml": include_html,
+        "include-svg": include_svg,
+        "include-html": include_html,
         "flatten": False,
     }
     req = requests.post(url, json=parameters)


### PR DESCRIPTION
This change applies the breaking changes in the next OQT release. This branch is supposed to be updated when more OQT changes are applied to `main`.

See also https://github.com/GIScience/ohsome-quality-analyst/issues/485

# TODOs
- [ ] Apply all remaining breaking changes from https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md#breaking-changes
- [ ] Update test fixtures
- [ ] Test manually by creating Report PDFs