### PR TITLE
Fix #243

### DIFF
--- a/sketch_map_tool/routes.py
+++ b/sketch_map_tool/routes.py
@@ -106,17 +106,21 @@ def digitize_results_post() -> Response:
         return redirect(url_for("digitize"))
     files = request.files.getlist("file")
     ids = db_client.insert_files(files)
-    file = db_client_flask.select_file(ids[0])
+    files_from_db = [db_client_flask.select_file(i) for i in ids]
     file_names = [db_client_flask.select_file_name(i) for i in ids]
-    args = upload_processing.read_qr_code(to_array(file))
-    uuid = args["uuid"]
-    bbox = args["bbox"]
-    map_frame_buffer = BytesIO(db_client_flask.select_map_frame(UUID(uuid)))
-    map_frame = to_array(map_frame_buffer.read())
+    args = [upload_processing.read_qr_code(to_array(file)) for file in files_from_db]
+    uuids = [args_["uuid"] for args_ in args]
+    bboxes = [args_["bbox"] for args_ in args]
+    map_frames = dict()
+    for uuid in set(uuids):  # Only retrieve map_frame once per uuid to save memory
+        map_frame_buffer = BytesIO(db_client_flask.select_map_frame(UUID(uuid)))
+        map_frames[uuid] = to_array(map_frame_buffer.read())
     result_id_1 = (
-        georeference_sketch_maps.s(ids, file_names, map_frame, bbox).apply_async().id
+        georeference_sketch_maps.s(ids, file_names, uuids, map_frames, bboxes).apply_async().id
     )
-    result_id_2 = digitize_sketches.s(ids, file_names, map_frame, bbox).apply_async().id
+    result_id_2 = (
+        digitize_sketches.s(ids, file_names, uuids, map_frames, bboxes).apply_async().id
+    )
     # Unique id for current request
     uuid = str(uuid4())
     # Mapping of request id to multiple tasks id's

--- a/sketch_map_tool/routes.py
+++ b/sketch_map_tool/routes.py
@@ -116,7 +116,9 @@ def digitize_results_post() -> Response:
         map_frame_buffer = BytesIO(db_client_flask.select_map_frame(UUID(uuid)))
         map_frames[uuid] = to_array(map_frame_buffer.read())
     result_id_1 = (
-        georeference_sketch_maps.s(ids, file_names, uuids, map_frames, bboxes).apply_async().id
+        georeference_sketch_maps.s(ids, file_names, uuids, map_frames, bboxes)
+        .apply_async()
+        .id
     )
     result_id_2 = (
         digitize_sketches.s(ids, file_names, uuids, map_frames, bboxes).apply_async().id

--- a/sketch_map_tool/tasks.py
+++ b/sketch_map_tool/tasks.py
@@ -117,7 +117,13 @@ def georeference_sketch_maps(
         buffer.seek(0)
         return buffer
 
-    return zip_([process(file_id, uuid, bbox) for file_id, uuid, bbox in zip(file_ids, uuids, bboxes)], file_names)
+    return zip_(
+        [
+            process(file_id, uuid, bbox)
+            for file_id, uuid, bbox in zip(file_ids, uuids, bboxes)
+        ],
+        file_names,
+    )
 
 
 @celery.task()


### PR DESCRIPTION
If sketch maps from different bboxes are uploaded simultaneously, retrieve the correct map frame for each selection to avoid distorded GeoTIFFs (and markings). To save memory, this is implemented in a way that only retrieves one map frame for each selection (identified by uuid, as you could have the same bbox but changed OSM data) used, meaning that if you have e.g. 10 sketch maps of uuid A and 10 of uuid B, only two map frames are retrieved.  
  
Example use case: Split a larger study area into multiple (potentially overlapping) subparts and, thus, generate multiple different sketch maps for it, but analysing the markings for the whole study area at once.