### PR TITLE
Close #207: Limit the max. number of uploaded files

### DIFF
--- a/config/sample.config.toml
+++ b/config/sample.config.toml
@@ -6,3 +6,4 @@ data-store = "redis://localhost:6379"
 wms-url = "https://maps.heigit.org/osm-carto/service?SERVICE=WMS&VERSION=1.1.1"
 wms-layers = "heigit:osm-carto@2xx"
 wms-read-timeout = 600
+max-nr-simultaneous-uploads = 100

--- a/sketch_map_tool/config.py
+++ b/sketch_map_tool/config.py
@@ -28,6 +28,7 @@ def load_config_default() -> Dict[str, str]:
         "wms-url": "https://maps.heigit.org/osm-carto/service?SERVICE=WMS&VERSION=1.1.1",
         "wms-layers": "heigit:osm-carto@2xx",
         "wms-read-timeout": 600,
+        "max-nr-simultaneous-uploads": 100,
     }
 
 
@@ -51,6 +52,7 @@ def load_config_from_env() -> Dict[str, str]:
         "wms-url": os.getenv("SMT-WMS-URL"),
         "wms-layers": os.getenv("SMT-WMS-LAYERS"),
         "wms-read-timeout": os.getenv("SMT-WMS-READ-TIMEOUT"),
+        "max-nr-simultaneous-uploads": os.getenv("SMT-MAX-NR-SIM-UPLOADS"),
     }
     return {k: v for k, v in cfg.items() if v is not None}
 

--- a/sketch_map_tool/exceptions.py
+++ b/sketch_map_tool/exceptions.py
@@ -10,6 +10,10 @@ class OQTReportError(Exception):
     pass
 
 
+class UploadLimitsExceededError(Exception):
+    pass
+
+
 class DatabaseError(Exception):
     pass
 

--- a/sketch_map_tool/routes.py
+++ b/sketch_map_tool/routes.py
@@ -10,6 +10,7 @@ from flask import Response, redirect, render_template, request, send_file, url_f
 from sketch_map_tool import celery_app, definitions
 from sketch_map_tool import flask_app as app
 from sketch_map_tool import tasks, upload_processing
+from sketch_map_tool.config import get_config_value
 from sketch_map_tool.database import client_flask as db_client_flask
 from sketch_map_tool.definitions import REQUEST_TYPES
 from sketch_map_tool.exceptions import (
@@ -105,7 +106,7 @@ def digitize_results_post() -> Response:
     if "file" not in request.files:
         return redirect(url_for("digitize"))
     files = request.files.getlist("file")
-    max_nr_simultaneous_uploads = 100
+    max_nr_simultaneous_uploads = int(get_config_value("max-nr-simultaneous-uploads"))
     if len(files) > max_nr_simultaneous_uploads:
         raise UploadLimitsExceededError(
             f"You can only upload up to {max_nr_simultaneous_uploads} files at once."

--- a/sketch_map_tool/routes.py
+++ b/sketch_map_tool/routes.py
@@ -10,7 +10,7 @@ from flask import Response, redirect, render_template, request, send_file, url_f
 from sketch_map_tool import celery_app, definitions
 from sketch_map_tool import flask_app as app
 from sketch_map_tool import tasks, upload_processing
-from sketch_map_tool.database import client_flask as db_client
+from sketch_map_tool.database import client_flask as db_client_flask
 from sketch_map_tool.definitions import REQUEST_TYPES
 from sketch_map_tool.exceptions import (
     FileNotFoundError_,
@@ -76,7 +76,7 @@ def create_results_post() -> Response:
         "sketch-map": str(task_sketch_map.id),
         "quality-report": str(task_quality_report.id),
     }
-    db_client.set_async_result_ids(uuid, map_)
+    db_client_flask.set_async_result_ids(uuid, map_)
     return redirect(url_for("create_results_get", uuid=uuid))
 
 
@@ -87,8 +87,8 @@ def create_results_get(uuid: str | None = None) -> Response | str:
         return redirect(url_for("create"))
     validate_uuid(uuid)
     # Check if celery tasks for UUID exists
-    _ = db_client.get_async_result_id(uuid, "sketch-map")
-    _ = db_client.get_async_result_id(uuid, "quality-report")
+    _ = db_client_flask.get_async_result_id(uuid, "sketch-map")
+    _ = db_client_flask.get_async_result_id(uuid, "quality-report")
     return render_template("create-results.html")
 
 
@@ -110,15 +110,15 @@ def digitize_results_post() -> Response:
         raise UploadLimitsExceededError(
             f"You can only upload up to {max_nr_simultaneous_uploads} files at once."
         )
-    ids = db_client.insert_files(files)
-    files_from_db = [db_client.select_file(i) for i in ids]
-    file_names = [db_client.select_file_name(i) for i in ids]
+    ids = db_client_flask.insert_files(files)
+    files_from_db = [db_client_flask.select_file(i) for i in ids]
+    file_names = [db_client_flask.select_file_name(i) for i in ids]
     args = [upload_processing.read_qr_code(to_array(file)) for file in files_from_db]
     uuids = [args_["uuid"] for args_ in args]
     bboxes = [args_["bbox"] for args_ in args]
     map_frames = dict()
     for uuid in set(uuids):  # Only retrieve map_frame once per uuid to save memory
-        map_frame_buffer = BytesIO(db_client.select_map_frame(UUID(uuid)))
+        map_frame_buffer = BytesIO(db_client_flask.select_map_frame(UUID(uuid)))
         map_frames[uuid] = to_array(map_frame_buffer.read())
     result_id_1 = (
         georeference_sketch_maps.s(ids, file_names, uuids, map_frames, bboxes)
@@ -135,7 +135,7 @@ def digitize_results_post() -> Response:
         "raster-results": str(result_id_1),
         "vector-results": str(result_id_2),
     }
-    db_client.set_async_result_ids(uuid, map_)
+    db_client_flask.set_async_result_ids(uuid, map_)
     id_ = uuid
     return redirect(url_for("digitize_results_get", uuid=id_))
 
@@ -154,7 +154,7 @@ def status(uuid: str, type_: REQUEST_TYPES) -> Response:
     validate_uuid(uuid)
     validate_type(type_)
 
-    id_ = db_client.get_async_result_id(uuid, type_)
+    id_ = db_client_flask.get_async_result_id(uuid, type_)
     task = celery_app.AsyncResult(id_)
 
     href = None
@@ -201,7 +201,7 @@ def download(uuid: str, type_: REQUEST_TYPES) -> Response:
     validate_uuid(uuid)
     validate_type(type_)
 
-    id_ = db_client.get_async_result_id(uuid, type_)
+    id_ = db_client_flask.get_async_result_id(uuid, type_)
     task = celery_app.AsyncResult(id_)
 
     match type_:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from sketch_map_tool import make_flask
 from sketch_map_tool.database import client_celery as db_client_celery
 from sketch_map_tool.database import client_flask as db_client_flask
 from sketch_map_tool.models import Bbox, PaperFormat, Size
+from sketch_map_tool.routes import digitize_results_post
 from tests import FIXTURE_DIR
 
 
@@ -50,6 +51,20 @@ def db_conn_celery():
 @pytest.fixture()
 def flask_app():
     yield make_flask()
+
+
+@pytest.fixture()
+def flask_client(flask_app):
+    flask_app.config.update(
+        {
+            "TESTING": True,
+        }
+    )
+    # Register routes to be tested:
+    flask_app.add_url_rule(
+        "/digitize/results", view_func=digitize_results_post, methods=["POST"]
+    )
+    return flask_app.test_client()
 
 
 @pytest.fixture

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -1,0 +1,27 @@
+import os
+from io import BytesIO
+
+import pytest
+
+from sketch_map_tool.exceptions import UploadLimitsExceededError
+
+
+def test_too_many_uploads(flask_client):
+    old_max_nr = os.getenv("SMT-MAX-NR-SIM-UPLOADS")
+    os.environ["SMT-MAX-NR-SIM-UPLOADS"] = "2"
+    with pytest.raises(UploadLimitsExceededError):
+        flask_client.post(
+            "/digitize/results",
+            data=dict(
+                file=[
+                    (BytesIO(b"File1"), "file1.png"),
+                    (BytesIO(b"File2"), "file2.png"),
+                    (BytesIO(b"File3"), "file3.png"),
+                ],
+            ),
+            follow_redirects=True,
+        )
+    if old_max_nr is None:
+        os.unsetenv("SMT-MAX-NR-SIM-UPLOADS")
+    else:
+        os.environ["SMT-MAX-NR-SIM-UPLOADS"] = old_max_nr

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -1,13 +1,13 @@
 import os
+from unittest import mock
 
 import pytest
 
 from sketch_map_tool.exceptions import FileNotFoundError_, UploadLimitsExceededError
 
 
+@mock.patch.dict(os.environ, {"SMT-MAX-NR-SIM-UPLOADS": "2"})
 def test_too_many_uploads(flask_client, sketch_map_markings_buffer_1):
-    old_max_nr = os.getenv("SMT-MAX-NR-SIM-UPLOADS")
-    os.environ["SMT-MAX-NR-SIM-UPLOADS"] = "2"
     with pytest.raises(UploadLimitsExceededError):
         flask_client.post(
             "/digitize/results",
@@ -20,16 +20,11 @@ def test_too_many_uploads(flask_client, sketch_map_markings_buffer_1):
             ),
             follow_redirects=True,
         )
-    if old_max_nr is None:
-        os.unsetenv("SMT-MAX-NR-SIM-UPLOADS")
-    else:
-        os.environ["SMT-MAX-NR-SIM-UPLOADS"] = old_max_nr
 
 
+@mock.patch.dict(os.environ, {"SMT-MAX-NR-SIM-UPLOADS": "2"})
 def test_allowed_nr_of_uploads(flask_client, sketch_map_markings_buffer_1):
     # Successful run requires that a sketch map has been generated on the instance beforehand
-    old_max_nr = os.getenv("SMT-MAX-NR-SIM-UPLOADS")
-    os.environ["SMT-MAX-NR-SIM-UPLOADS"] = "2"
     with pytest.raises(
         FileNotFoundError_
     ):  # uuid of test image not in database, but the exception shows that the uploads have been accepted and processed
@@ -43,7 +38,3 @@ def test_allowed_nr_of_uploads(flask_client, sketch_map_markings_buffer_1):
             ),
             follow_redirects=True,
         )
-    if old_max_nr is None:
-        os.unsetenv("SMT-MAX-NR-SIM-UPLOADS")
-    else:
-        os.environ["SMT-MAX-NR-SIM-UPLOADS"] = old_max_nr

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -1,12 +1,11 @@
 import os
-from io import BytesIO
 
 import pytest
 
-from sketch_map_tool.exceptions import UploadLimitsExceededError
+from sketch_map_tool.exceptions import FileNotFoundError_, UploadLimitsExceededError
 
 
-def test_too_many_uploads(flask_client):
+def test_too_many_uploads(flask_client, sketch_map_markings_buffer_1):
     old_max_nr = os.getenv("SMT-MAX-NR-SIM-UPLOADS")
     os.environ["SMT-MAX-NR-SIM-UPLOADS"] = "2"
     with pytest.raises(UploadLimitsExceededError):
@@ -14,9 +13,32 @@ def test_too_many_uploads(flask_client):
             "/digitize/results",
             data=dict(
                 file=[
-                    (BytesIO(b"File1"), "file1.png"),
-                    (BytesIO(b"File2"), "file2.png"),
-                    (BytesIO(b"File3"), "file3.png"),
+                    (sketch_map_markings_buffer_1, "file1.png"),
+                    (sketch_map_markings_buffer_1, "file2.png"),
+                    (sketch_map_markings_buffer_1, "file3.png"),
+                ],
+            ),
+            follow_redirects=True,
+        )
+    if old_max_nr is None:
+        os.unsetenv("SMT-MAX-NR-SIM-UPLOADS")
+    else:
+        os.environ["SMT-MAX-NR-SIM-UPLOADS"] = old_max_nr
+
+
+def test_allowed_nr_of_uploads(flask_client, sketch_map_markings_buffer_1):
+    # Successful run requires that a sketch map has been generated on the instance beforehand
+    old_max_nr = os.getenv("SMT-MAX-NR-SIM-UPLOADS")
+    os.environ["SMT-MAX-NR-SIM-UPLOADS"] = "2"
+    with pytest.raises(
+        FileNotFoundError_
+    ):  # uuid of test image not in database, but the exception shows that the uploads have been accepted and processed
+        flask_client.post(
+            "/digitize/results",
+            data=dict(
+                file=[
+                    (sketch_map_markings_buffer_1, "file1.png"),
+                    (sketch_map_markings_buffer_1, "file2.png"),
                 ],
             ),
             follow_redirects=True,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -94,7 +94,7 @@ def test_get_config(config_keys):
 def test_get_config_value(config_keys):
     for key in config_keys:
         val = config.get_config_value(key)
-        if key in ["wms-read-timeout"]:
+        if key in ["wms-read-timeout", "max-nr-simultaneous-uploads"]:
             assert isinstance(val, int)
         else:
             assert isinstance(val, str)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -27,6 +27,7 @@ def config_keys():
         "wms-url",
         "wms-layers",
         "wms-read-timeout",
+        "max-nr-simultaneous-uploads",
     )
 
 

--- a/tests/unit/test_routes_api.py
+++ b/tests/unit/test_routes_api.py
@@ -13,7 +13,7 @@ def client():
 def mock_request_task_mapping(uuid, monkeypatch):
     """Mock request id to task id mapping."""
     monkeypatch.setattr(
-        "sketch_map_tool.routes.db_client.get_async_result_id", lambda uuid, type_: uuid
+        "sketch_map_tool.routes.db_client_flask.get_async_result_id", lambda uuid, type_: uuid
     )
 
 

--- a/tests/unit/test_routes_create.py
+++ b/tests/unit/test_routes_create.py
@@ -60,7 +60,7 @@ def test_create_result_post(client, mock_tasks, monkeypatch, bbox, bbox_wgs84):
 
 def test_create_results_uuid(client, uuid, monkeypatch):
     monkeypatch.setattr(
-        "sketch_map_tool.routes.db_client.get_async_result_id", lambda a, b: None
+        "sketch_map_tool.routes.db_client_flask.get_async_result_id", lambda a, b: None
     )
     resp = client.get("/create/results/{0}".format(uuid))
     assert resp.status_code == 200


### PR DESCRIPTION
As we once defined 80 uploads per user as upper boundary of what should be sufficient for the vast majority of uses, I set a value slightly above that (100). In case one needs more, one can of course always split up the uploads and later merge the files in a GIS. As this value is, therefore, theoretically reasoned and should be valid for all instances of the tool, it is not included in the config. However, if you deem it sensible to set this value in the config, I can change it accordingly.