### PR TITLE
Close #186 and fix #250 Allow bookmarking and sharing of map selections (center points)

### DIFF
--- a/client-src/create/form.js
+++ b/client-src/create/form.js
@@ -106,6 +106,12 @@ function bindFormToPrintLayoutControl(printLayoutControl) {
             printLayoutControl.handleBboxChange();
             document.querySelector("#page-setup-form").submit();
         });
+
+    // update the URL when the selection is changed  (e.g. to bookmark the current selection)
+    printLayoutControl.on("change:bbox", (event) => {
+        const newCenter = printLayoutControl.getMap().getView().getCenter();
+        window.history.replaceState({}, document.title, `?center=${newCenter}`);
+    });
 }
 
 export {

--- a/client-src/create/form.js
+++ b/client-src/create/form.js
@@ -1,4 +1,7 @@
 import { PAPER_FORMAT, ORIENTATION, Margin } from "@giscience/ol-print-layout-control";
+import {
+    toLonLat, get as getProjection, transformExtent,
+} from "ol/proj";
 import { SKETCH_MAP_MARGINS } from "./sketchMapMargins";
 import { fillSelectOptions, setDisabled } from "../shared";
 
@@ -46,14 +49,18 @@ function bindFormToPrintLayoutControl(printLayoutControl) {
     // property: bbox (in webmercator)
     document.getElementById("bbox").value = JSON.stringify(printLayoutControl.getBbox());
     printLayoutControl.on("change:bbox", (event) => {
-        const newBbox = event.target.getBbox();
-        document.getElementById("bbox").value = JSON.stringify(newBbox);
+        let newBbox = event.target.getBbox();
+        newBbox = toLonLat(newBbox.slice(0, 2)).concat(toLonLat(newBbox.slice(2, 4))); // See https://github.com/GIScience/sketch-map-tool/issues/250
+        document.getElementById("bbox").value = JSON.stringify(
+            transformExtent(newBbox, getProjection("EPSG:4326"), getProjection("EPSG:3857")),
+        );
     });
 
     // property: bboxWGS84 (in wgs84)
     document.getElementById("bboxWGS84").value = JSON.stringify(printLayoutControl.getBboxAsLonLat());
     printLayoutControl.on("change:bbox", (event) => {
-        const newBbox = event.target.getBboxAsLonLat();
+        let newBbox = event.target.getBbox();
+        newBbox = toLonLat(newBbox.slice(0, 2)).concat(toLonLat(newBbox.slice(2, 4))); // See https://github.com/GIScience/sketch-map-tool/issues/250
         document.getElementById("bboxWGS84").value = JSON.stringify(newBbox);
     });
 

--- a/client-src/create/index.js
+++ b/client-src/create/index.js
@@ -7,7 +7,18 @@ import "./create.css";
 import { createMap, addPrintLayoutControl, addGeocoderControl } from "./map.js";
 import { bindFormToPrintLayoutControl } from "./form.js";
 
+// Retrieve potentially given map center from URL (e.g. from a bookmarked selection)
+const searchParams = new URLSearchParams(window.location.search);
+const centerArg = searchParams.get("center");
+
 const map = createMap("map", [8.68, 49.41], 15);
+
+if (centerArg != null) {
+    const centerCoords = centerArg.split(",");
+    const center = [parseFloat(centerCoords[0]), parseFloat(centerCoords[1])];
+    map.getView().setCenter(center);
+}
+
 const printLayoutControl = addPrintLayoutControl(map);
 bindFormToPrintLayoutControl(printLayoutControl);
 addGeocoderControl(map);

--- a/client-src/create/index.js
+++ b/client-src/create/index.js
@@ -11,13 +11,13 @@ import { bindFormToPrintLayoutControl } from "./form.js";
 const searchParams = new URLSearchParams(window.location.search);
 const centerArg = searchParams.get("center");
 
-const map = createMap("map", [8.68, 49.41], 15);
-
+let center = [966253.1800856147, 6344703.99262965];
 if (centerArg != null) {
     const centerCoords = centerArg.split(",");
-    const center = [parseFloat(centerCoords[0]), parseFloat(centerCoords[1])];
-    map.getView().setCenter(center);
+    center = [parseFloat(centerCoords[0]), parseFloat(centerCoords[1])];
 }
+
+const map = createMap("map", center, 15);
 
 const printLayoutControl = addPrintLayoutControl(map);
 bindFormToPrintLayoutControl(printLayoutControl);

--- a/client-src/create/map.js
+++ b/client-src/create/map.js
@@ -1,6 +1,5 @@
 import { Map, View } from "ol";
 import { Tile } from "ol/layer";
-import { fromLonLat } from "ol/proj";
 import { OSM } from "ol/source";
 import Geocoder from "@kirtandesai/ol-geocoder";
 import { PrintLayout, PAPER_FORMAT, ORIENTATION } from "@giscience/ol-print-layout-control";
@@ -14,11 +13,11 @@ import { SKETCH_MAP_MARGINS } from "./sketchMapMargins.js";
  * @param {number} [zoom=15] - the zoomlevel in which the map will be initialized
  * @returns {Map}
  */
-function createMap(target = "map", lonLat = [8.68, 49.41], zoom = 15) {
+function createMap(target = "map", lonLat = [966253.1800856147, 6344703.99262965], zoom = 15) {
     const map = new Map({
         target,
         view: new View({
-            center: fromLonLat(lonLat),
+            center: lonLat,
             zoom,
             maxZoom: 20,
             enableRotation: false,


### PR DESCRIPTION
Potential uses:
You want to make sure to have the same selection at two separate sessions, e.g. to inspect changes after a mapathon, so you need the center point (and orientation, zoom and paper format settings). Or to simply improve usability in a way that you don't have to always search / drag to the wider area you are concerned with, but directly loading the map focussed on it.