### PR TITLE
fix(ui): display error information also for 500

### DIFF
--- a/client-src/shared/poll/poll.js
+++ b/client-src/shared/poll/poll.js
@@ -77,12 +77,7 @@ async function poll(url, prefix) {
             status: taskStatus,
         } = resonseJSON;
         // display error
-        if (httpStatus === 500) {
-            handleError(prefix, `${new Date().toISOString()} ${taskStatus} <br>
-            There was an Internal Server Error.`);
-        } else {
-            handleError(prefix, `${new Date().toISOString()} ${taskStatus} <br> ${errorText}`);
-        }
+        handleError(prefix, `${new Date().toISOString()} ${httpStatus} ${taskStatus} <br> ${errorText}`);
         // remove task status
         setTaskStatus(`${prefix}-status`, "");
     }

--- a/sketch_map_tool/routes.py
+++ b/sketch_map_tool/routes.py
@@ -196,7 +196,7 @@ def status(uuid: str, type_: REQUEST_TYPES, lang="en") -> Response:
                 error = err.translate()
             except Exception as err:
                 http_status = 500  # Internal Server Error
-                error = repr(err)
+                error = "{}: {}".format(type(err).__name__, str(err))
     else:  # PENDING, RETRY, STARTED
         # Accepted for processing, but has not been completed
         http_status = 202  # Accepted


### PR DESCRIPTION
previously only error messages for error which did not return with HTTP 500 status code got displayed in the information.

The problem has been that in the case of 500 HTTP status code the error message of the backend error has not been shown to the user.