### PR TITLE
fix(db): clean-up blobs based on file ids

### DIFF
--- a/sketch_map_tool/database/client_celery.py
+++ b/sketch_map_tool/database/client_celery.py
@@ -130,7 +130,7 @@ def cleanup_map_frames():
             logging.info("Table `map_frame` does not exist yet. Nothing todo.")
 
 
-def cleanup_blob(map_frame_uuids: list[UUID]):
+def cleanup_blob(file_ids: list[int] | tuple[int]):
     """Cleanup uploaded files (sketch maps) without consent.
 
     Only set file and name to null. Keep metadata.
@@ -143,12 +143,12 @@ def cleanup_blob(map_frame_uuids: list[UUID]):
         file = NULL,
         file_name = NULL
     WHERE
-        map_frame_uuid = %s
+        id = %s
         AND consent = FALSE;
     """
     with db_conn.cursor() as curs:
         try:
-            curs.executemany(query, [[i] for i in map_frame_uuids])
+            curs.executemany(query, [[i] for i in file_ids])
         except UndefinedTable:
             logging.info("Table `blob` does not exist yet. Nothing todo.")
 

--- a/sketch_map_tool/tasks.py
+++ b/sketch_map_tool/tasks.py
@@ -236,11 +236,11 @@ def cleanup_map_frames():
 
 
 @celery.task
-def cleanup_blobs(*_, map_frame_uuids: list):
+def cleanup_blobs(*_, file_ids: list[int]):
     """Cleanup uploaded files stored in the database.
 
     Arguments are ignored. They are only part of the signature because of the usage in
     a celery chain.
     """
-    db_client_celery.cleanup_blob(map_frame_uuids)
+    db_client_celery.cleanup_blob(file_ids)
     return True

--- a/tests/integration/test_database_client_celery.py
+++ b/tests/integration/test_database_client_celery.py
@@ -174,9 +174,11 @@ def test_cleanup_blobs_with_consent(
     sketch_map_marked: bytes,
 ):
     """Sketch map has been uploaded with consent. Nothing should happen."""
-    client_celery.cleanup_blob([UUID(uuid_create), UUID(uuid_create)])
     with flask_app.app_context():
         with client_flask.open_connection().cursor() as curs:
+            curs.execute("SELECT id FROM blob WHERE map_frame_uuid = %s", [uuid_create])
+            file_ids = curs.fetchall()[0]
+            client_celery.cleanup_blob(file_ids)
             curs.execute(
                 "SELECT file FROM blob WHERE map_frame_uuid = %s", [uuid_create]
             )
@@ -191,9 +193,11 @@ def test_cleanup_blobs_without_consent(flask_app, uuid_create: str):
 
     Sketch map file and name should be set to null.
     """
-    client_celery.cleanup_blob([UUID(uuid_create)])
     with flask_app.app_context():
         with client_flask.open_connection().cursor() as curs:
+            curs.execute("SELECT id FROM blob WHERE map_frame_uuid = %s", [uuid_create])
+            file_ids = curs.fetchall()[0]
+            client_celery.cleanup_blob(file_ids)
             curs.execute(
                 "SELECT file, file_name FROM blob WHERE map_frame_uuid = %s",
                 [uuid_create],


### PR DESCRIPTION
clean-up blobs based on file ids not uuid to avoid remove blobs with same uuid but uploaded separately.