### PR TITLE
Docker: split dockerfile in runtime and builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:16-slim AS bundler
+# build node app
+FROM node:16-slim AS node-builder
 
 # install JS dependencies
 COPY package.json package.json
@@ -10,37 +11,65 @@ RUN mkdir -p /sketch_map_tool/static/bundles
 RUN npm run build
 
 
-FROM ubuntu:24.04
+# build python app
+FROM python:3.12-bookworm AS python-builder
 
-RUN apt update \
-    && apt install -y --no-upgrade \
-    python3 \
-    python3-pip \
-    python3-gdal \
-    git \
-    libgdal-dev \
-    libpq-dev \
-    libzbar0 \
-    libfreetype6-dev \
-    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt update \
+    && apt install -y --no-upgrade --no-install-recommends \
+        libfreetype6-dev \
+        libgdal-dev \
+        libpq-dev \
+        libzbar0 \
+        python3-gdal
 
 ENV POETRY_NO_INTERACTION=1 \
+    POETRY_VIRTUALENVS_IN_PROJECT=1 \
+    POETRY_VIRTUALENVS_CREATE=1 \
+    POETRY_CACHE_DIR=/tmp/poetry_cache \
     POETRY_REQUESTS_TIMEOUT=600
 
-COPY pyproject.toml poetry.lock .
+COPY pyproject.toml poetry.lock ./
 
-RUN python3 -m pip install --break-system-packages poetry setuptools \
+RUN --mount=type=cache,target=$POETRY_CACHE_DIR python3 -m pip install --break-system-packages poetry setuptools \
     && python3 -m poetry install --only main --no-root --no-directory
 
 COPY sketch_map_tool sketch_map_tool
 COPY data data
 COPY config config
 
-RUN python3 -m poetry install --only main --no-root --no-directory \
+RUN --mount=type=cache,target=$POETRY_CACHE_DIR python3 -m poetry install --only main --no-root --no-directory \
     && python3 -m poetry run python -m pip install \
         gdal[numpy]=="$(gdal-config --version).*" \
         psycopg2 \
     && python3 -m poetry run pybabel compile -d sketch_map_tool/translations
 
-COPY --from=bundler --chown=smt:smt /sketch_map_tool/static/bundles sketch_map_tool/static/bundles
+
+# final image
+FROM python:3.12-slim-bookworm AS runtime
+
+WORKDIR /app
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt update \
+    && apt install -y --no-upgrade --no-install-recommends \
+        libgdal32 \
+        libzbar0
+
+ENV VIRTUAL_ENV=/app/.venv \
+    PATH="/app/.venv/bin:$PATH"
+
+COPY --from=python-builder --chown=smt:smt $VIRTUAL_ENV $VIRTUAL_ENV
+COPY --chown=smt:smt sketch_map_tool sketch_map_tool
+COPY --chown=smt:smt data data
+COPY --chown=smt:smt config config
+COPY --from=node-builder --chown=smt:smt /sketch_map_tool/static/bundles sketch_map_tool/static/bundles
 # use entry-points defined in docker-compose file

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,8 +17,6 @@ services:
       - "127.0.0.1:8081:8080"
     entrypoint:
       [
-        "poetry",
-        "run",
         "waitress-serve",
         "sketch_map_tool.routes:app",
       ]
@@ -28,7 +26,7 @@ services:
       context: ./
       dockerfile: Dockerfile
     volumes:
-      - ./weights:/weights
+      - ./weights:/app/weights
     restart: unless-stopped
     depends_on:
       - redis
@@ -39,8 +37,6 @@ services:
           memory: 16G
     entrypoint:
       [
-        "poetry",
-        "run",
         "celery",
         "--app",
         "sketch_map_tool.tasks",
@@ -68,8 +64,6 @@ services:
       - celery
     entrypoint:
       [
-        "poetry",
-        "run",
         "celery",
         "--app",
         "sketch_map_tool.tasks",

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
       context: ./
       dockerfile: Dockerfile
     volumes:
-      - ./weights:/weights
+      - ./weights:/app/weights
     restart: unless-stopped
     # deploy:
     #   resources:


### PR DESCRIPTION
Improve Docker build image:
 - use build caches for `apt` and `poetry`
 - split build and runtime images
 - use Debian-based python (slim) image, not Ubuntu
 - do not use poetry in runtime image, just the venv

Idea comes from: https://medium.com/@albertazzir/blazing-fast-python-docker-builds-with-poetry-a78a66f5aed0