### PR TITLE
refactor: remove unused code

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from celery.result import AsyncResult, GroupResult
 from werkzeug.datastructures import FileStorage
 
-from sketch_map_tool.exceptions import QRCodeError, UUIDNotFoundError
+from sketch_map_tool.exceptions import QRCodeError
 from sketch_map_tool.models import Bbox, Layer, PaperFormat, Size
 from sketch_map_tool.routes import app
 from tests import FIXTURE_DIR
@@ -169,22 +169,6 @@ def file(sketch_map_buffer):
 @pytest.fixture
 def files(file):
     return [file, file]
-
-
-@pytest.fixture(autouse=True)
-def mock_request_task_mapping(monkeypatch):
-    """Mock every request id to task id mapping .
-
-    This mapping is only present because of legacy support.
-    """
-
-    def raise_(exception):
-        raise exception
-
-    monkeypatch.setattr(
-        "sketch_map_tool.routes.db_client_flask.get_async_result_id",
-        lambda *_: raise_(UUIDNotFoundError("")),
-    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_routes_api_download.py
+++ b/tests/unit/test_routes_api_download.py
@@ -5,26 +5,26 @@ import pytest
 from celery.result import GroupResult
 
 
-@pytest.mark.usefixtures("mock_request_task_mapping", "mock_async_result_success")
+@pytest.mark.usefixtures("mock_async_result_success")
 def test_download_success(client, uuid):
     resp = client.get("/api/download/{0}/sketch-map".format(uuid))
     assert resp.status_code == 200
     assert resp.mimetype == "application/pdf"
 
 
-@pytest.mark.usefixtures("mock_request_task_mapping", "mock_async_result_started")
+@pytest.mark.usefixtures("mock_async_result_started")
 def test_download_started(client, uuid):
     resp = client.get("/api/download/{0}/sketch-map".format(uuid))
     assert resp.status_code == 500
 
 
-@pytest.mark.usefixtures("mock_request_task_mapping", "mock_async_result_failure")
+@pytest.mark.usefixtures("mock_async_result_failure")
 def test_download_failure(client, uuid):
     resp = client.get("/api/download/{0}/sketch-map".format(uuid))
     assert resp.status_code == 500
 
 
-@pytest.mark.usefixtures("mock_request_task_mapping", "mock_group_result_success")
+@pytest.mark.usefixtures("mock_group_result_success")
 @pytest.mark.parametrize("type_", ["raster-results", "vector-results"])
 def test_group_download_success(client, uuid, type_, monkeypatch):
     monkeypatch.setattr(
@@ -40,31 +40,27 @@ def test_group_download_success(client, uuid, type_, monkeypatch):
     assert resp.mimetype in ["application/zip", "application/geo+json"]
 
 
-@pytest.mark.usefixtures("mock_request_task_mapping", "mock_group_result_started")
+@pytest.mark.usefixtures("mock_group_result_started")
 @pytest.mark.parametrize("type_", ("raster-results", "vector-results"))
 def test_group_started(client, uuid, type_):
     resp = client.get("/api/download/{0}/{1}".format(uuid, type_))
     assert resp.status_code == 500
 
 
-@pytest.mark.usefixtures("mock_request_task_mapping", "mock_group_result_failure")
+@pytest.mark.usefixtures("mock_group_result_failure")
 @pytest.mark.parametrize("type_", ("raster-results", "vector-results"))
 def test_group_failure(client, uuid, type_):
     resp = client.get("/api/download/{0}/{1}".format(uuid, type_))
     assert resp.status_code == 500
 
 
-@pytest.mark.usefixtures(
-    "mock_request_task_mapping",
-    "mock_group_result_started_success_failure",
-)
+@pytest.mark.usefixtures("mock_group_result_started_success_failure")
 @pytest.mark.parametrize("type_", ("raster-results", "vector-results"))
 def test_group_started_success_failure(client, uuid, type_):
     resp = client.get("/api/download/{0}/{1}".format(uuid, type_))
     assert resp.status_code == 500
 
 
-@pytest.mark.usefixtures("mock_request_task_mapping")
 @pytest.mark.parametrize("type_", ("raster-results", "vector-results"))
 def test_group_success_failure(
     client,

--- a/tests/unit/test_routes_api_status.py
+++ b/tests/unit/test_routes_api_status.py
@@ -4,7 +4,6 @@ import pytest
 def test_status_success(
     client,
     uuid,
-    mock_request_task_mapping,
     mock_async_result_success,
 ):
     resp = client.get("/api/status/{0}/sketch-map".format(uuid))
@@ -20,7 +19,6 @@ def test_status_success(
 def test_status_started(
     client,
     uuid,
-    mock_request_task_mapping,
     mock_async_result_started,
 ):
     resp = client.get("/api/status/{0}/sketch-map".format(uuid))
@@ -36,7 +34,6 @@ def test_status_started(
 def test_status_failure(
     client,
     uuid,
-    mock_request_task_mapping,
     mock_async_result_failure,
 ):
     resp = client.get("/api/status/{0}/sketch-map".format(uuid))
@@ -51,7 +48,6 @@ def test_status_failure(
 def test_status_failure_hard(
     client,
     uuid,
-    mock_request_task_mapping,
     mock_async_result_failure_hard,
 ):
     resp = client.get("/api/status/{0}/sketch-map".format(uuid))
@@ -63,7 +59,6 @@ def test_group_status_success(
     client,
     uuid,
     type_,
-    mock_request_task_mapping,
     mock_group_result_success,
 ):
     resp = client.get("/api/status/{0}/{1}".format(uuid, type_))
@@ -80,7 +75,6 @@ def test_group_status_started(
     client,
     uuid,
     type_,
-    mock_request_task_mapping,
     mock_group_result_started,
 ):
     resp = client.get("/api/status/{0}/{1}".format(uuid, type_))
@@ -97,7 +91,6 @@ def test_group_status_failure(
     client,
     uuid,
     type_,
-    mock_request_task_mapping,
     mock_group_result_failure,
 ):
     resp = client.get("/api/status/{0}/{1}".format(uuid, type_))
@@ -114,7 +107,6 @@ def test_group_status_failure_hard(
     client,
     uuid,
     type_,
-    mock_request_task_mapping,
     mock_group_result_failure_hard,
 ):
     resp = client.get("/api/status/{0}/{1}".format(uuid, type_))
@@ -126,7 +118,6 @@ def test_group_status_started_success_failure(
     client,
     uuid,
     type_,
-    mock_request_task_mapping,
     mock_group_result_started_success_failure,
 ):
     resp = client.get("/api/status/{0}/{1}".format(uuid, type_))
@@ -144,7 +135,6 @@ def test_group_status_success_failure(
     client,
     uuid,
     type_,
-    mock_request_task_mapping,
     mock_group_result_success_failure,
 ):
     resp = client.get("/api/status/{0}/{1}".format(uuid, type_))


### PR DESCRIPTION
Remove functions which were needed for the amount of time Celery keeps results in the Result Store (24h) during transition to new code.
